### PR TITLE
Fix usage example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ import Legobot
 HOST = 'irc.freenode.com'
 PORT = 6667
 NICK = 'legobot'
-CHANS = [('#freenoode',''),('#bitcoin',''),('#legobot','')] #List of tuples. Format is (channel,password)
-myBot = Legobot.legoBot(host=HOST,port=PORT,nick=NICK,chans=CHANS)
+CHANS = [('#freenoode', ''), ('#bitcoin', ''), ('#legobot', '')] # List of tuples. Format is (channel, password)
+myBot = Legobot.legoBot(host=HOST, port=PORT, nick=NICK, nickpass="", chans=CHANS)
 ```
 
 #### Great, now what?
@@ -41,7 +41,7 @@ def helloWorld(msg):
     return "Hello, world!"
 
 myBot.addFunc("!helloworld", helloWorld, "Ask your bot to say hello. Usage: !helloworld")
-mybot.connect(isSSL=False)
+myBot.connect(isSSL=False)
 ```
 
 Then watch your creation come to life:


### PR DESCRIPTION
Usage example on README.md does not work, as `nickpass` is missing from the `init()` parameters.

```
Traceback (most recent call last):
  File "bot.py", line 6, in <module>
    myBot = Legobot.legoBot(host=HOST,port=PORT,nick=NICK,chans=CHANS)
TypeError: __init__() takes at least 6 arguments (5 given)
```

In addition the ``myBot`` object name has a typo on ``connect()`` method call.

This PR fixes both issues.