### PR TITLE
Allow IRC connector to authenticate with Freenode NickServ

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [1.0.2] 2016-12-12
+
+### Added
+
+- Allow IRC connector to authenticate to Freenode-style nickserv
 
 ## [1.0.1] 2016-12-08
 

--- a/Legobot/Connectors/IRC.py
+++ b/Legobot/Connectors/IRC.py
@@ -110,19 +110,18 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
             logger.debug('Attempting to join %s' % channel)
             c.join(channel)
 
-        if nickserv == True and nickserv_pass != None:
-            self.identify(self.nickserv_pass)
+        if self.nickserv == True and self.nickserv_pass != None:
+            self.identify(c,e,self.nickserv_pass)
         else:
             logger.error('If nickserv is enabled, you must supply a password')
 
-        if nickserv == False and nickserv_pass != None:
-            logger.warn('It appears you provided a nickserv password but\
-                    did not enable nickserv authentication')
+        if self.nickserv == False and self.nickserv_pass != None:
+            logger.warn('It appears you provided a nickserv password but '\
+                    'did not enable nickserv authentication')
 
     def identify(self,c,e,password):
-        c.privmsg('NickServ','IDENTIFY %s %s' % (self.nick,password))
+        c.privmsg('NickServ','IDENTIFY %s %s' % (self.nickname,password))
         return
-
 
     def run(self):
         """

--- a/Legobot/Connectors/IRC.py
+++ b/Legobot/Connectors/IRC.py
@@ -30,7 +30,8 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
     """
     def __init__(self, baseplate, channels, nickname, server,
                  port=6667, use_ssl=False, password=None,
-                 username=None, ircname=None):
+                 username=None, ircname=None, nickserv=False,
+                 nickserv_pass=None):
         irc.bot.SingleServerIRCBot.__init__(self,
                                             [(server, port)],
                                             nickname,
@@ -47,6 +48,8 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
         self.password = password
         self.username = username
         self.ircname = ircname
+        self.nickserv = nickserv
+        self.nickserv_pass = nickserv_pass
 
     def connect(self, *args, **kwargs):
         """
@@ -106,6 +109,20 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
         for channel in self.my_channels:
             logger.debug('Attempting to join %s' % channel)
             c.join(channel)
+
+        if nickserv == True and nickserv_pass != None:
+            self.identify(self.nickserv_pass)
+        else:
+            logger.error('If nickserv is enabled, you must supply a password')
+
+        if nickserv == False and nickserv_pass != None:
+            logger.warn('It appears you provided a nickserv password but\
+                    did not enable nickserv authentication')
+
+    def identify(self,c,e,password):
+        c.privmsg('NickServ','IDENTIFY %s %s' % (self.nick,password))
+        return
+
 
     def run(self):
         """

--- a/examples/exmaplebot.py
+++ b/examples/exmaplebot.py
@@ -8,7 +8,7 @@ from Legobot.Legos.Help import Help
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
+ch.setLevel(logging.WARN)
 # create formatter and add it to the handlers
 formatter = logging.Formatter(
     '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -26,11 +26,13 @@ master_proxy = master.proxy()
 
 # Add children
 master_proxy.add_child(IRC,
-                          channels=['#social'],
+                          channels=['#foo','#bar'],
                           nickname='legobot',
-                          server='irc.sithmail.com',
+                          server='chat.freenode.net',
                           port=6697,
                           use_ssl=True,
                           username=None,
-                          password=None)
+                          password=None,
+                          nickserv=True,
+                          nickserv_pass='correcthorsebatterystaple')
 master_proxy.add_child(Help)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='Legobot',
 
-    version='1.0.1',
+    version='1.0.2',
 
     license='GPLv2',
 


### PR DESCRIPTION
Resolves #102 

My main concern around this one is in interfacing with the user/bot script. Should we prompt for what type of NickServ auth string they use or try to guess based on domain we connect to?