### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Legobot/Connectors/IRC.py
+++ b/Legobot/Connectors/IRC.py
@@ -93,7 +93,7 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
         """
         text = e.arguments[0]
         metadata = Metadata(source=self).__dict__
-        logger.debug('\n\n\n%s\n\n\n' % e.source)
+        logger.debug('\n\n\n{0!s}\n\n\n'.format(e.source))
         metadata['source_channel'] = e.source.split('!')[0]
         metadata['source_username'] = e.source.split('!')[0]
         metadata['source_user'] = e.source
@@ -107,7 +107,7 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
         This function runs when the bot successfully connects to the IRC server
         """
         for channel in self.my_channels:
-            logger.debug('Attempting to join %s' % channel)
+            logger.debug('Attempting to join {0!s}'.format(channel))
             c.join(channel)
 
         if self.nickserv == True and self.nickserv_pass != None:
@@ -120,7 +120,7 @@ class IRCBot(threading.Thread, irc.bot.SingleServerIRCBot):
                     'did not enable nickserv authentication')
 
     def identify(self,c,e,password):
-        c.privmsg('NickServ','IDENTIFY %s %s' % (self.nickname,password))
+        c.privmsg('NickServ','IDENTIFY {0!s} {1!s}'.format(self.nickname, password))
         return
 
     def run(self):

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -16,7 +16,7 @@ class Help(Lego):
         try:
             target = message['metadata']['source_channel']
         except IndexError:
-            logger.error('Could not identify message source in message: %s' % str(message))
+            logger.error('Could not identify message source in message: {0!s}'.format(str(message)))
         try:
             function = message['text'].split()[1]
         except IndexError:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bbriggs:Legobot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bbriggs:Legobot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)