### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -125,7 +125,7 @@ class RtmBot(threading.Thread, object):
             else:
                 metadata['is_private_message'] = False
 
-        logger.debug('Metadata:\n\n%s' % metadata)
+        logger.debug('Metadata:\n\n{0!s}'.format(metadata))
 
         return metadata
 

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -13,7 +13,7 @@ class Help(Lego):
             try:
                 return message['text'].split()[0] == '!help'
             except Exception as e:
-                logger.error('Help lego failed to check message text: %s' % e)
+                logger.error('Help lego failed to check message text: {0!s}'.format(e))
                 return False
 
     def handle(self, message):

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -13,7 +13,8 @@ class Help(Lego):
             try:
                 return message['text'].split()[0] == '!help'
             except Exception as e:
-                logger.error('Help lego failed to check message text: {0!s}'.format(e))
+                logger.error(
+                    'Help lego failed to check message text: {0!s}'.format(e))
                 return False
 
     def handle(self, message):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bbriggs:Legobot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bbriggs:Legobot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)